### PR TITLE
renamed typo in flair title

### DIFF
--- a/wiki/resources/official-badges.md
+++ b/wiki/resources/official-badges.md
@@ -328,7 +328,7 @@ Discord badges are epic-looking achievements to make your profile look cool. The
       <td>Only for the Clyde Ai bot.</td>
    </tr>
    <tr>
-      <td>Ai</td>
+      <td>Original Poster</td>
       <td><img src="/img/special/OriginalPoster.svg"></img></td>
       <td>✅</td>
       <td>Given to the original poster of a forum post.</td>

--- a/wiki/resources/official-badges.md
+++ b/wiki/resources/official-badges.md
@@ -328,7 +328,7 @@ Discord badges are epic-looking achievements to make your profile look cool. The
       <td>Only for the Clyde Ai bot.</td>
    </tr>
    <tr>
-      <td>Original Poster</td>
+      <td>OP (Original Poster)</td>
       <td><img src="/img/special/OriginalPoster.svg"></img></td>
       <td>✅</td>
       <td>Given to the original poster of a forum post.</td>


### PR DESCRIPTION
renamed a typo in a flair title which shows the "Original Poster" flair but had "Ai" from the flair above.