### PR TITLE
Change HypeSquad badge statuses to '❌'

### DIFF
--- a/wiki/resources/official-badges.md
+++ b/wiki/resources/official-badges.md
@@ -50,21 +50,21 @@ Discord badges are epic-looking achievements to make your profile look cool. The
    <tr>
       <td>HypeSquad Brilliance</td>
       <td><img src="/img/hypesquadbrilliance.svg"></img></td>
-      <td>✅</td>
+      <td>❌</td>
       <td>Taking the HypeSquad <a href="https://support.discord.com/hc/en-us/articles/360007553672-HypeSquad-House-Breakdown">Test</a>.</td>
       <td>128 (2^7)</td>
    </tr>
    <tr>
       <td>HypeSquad Bravery</td>
       <td><img src="/img/hypesquadbravery.svg"></img></td>
-      <td>✅</td>
+      <td>❌</td>
       <td>Taking the HypeSquad <a href="https://support.discord.com/hc/en-us/articles/360007553672-HypeSquad-House-Breakdown">Test</a>.</td>
       <td>64 (2^6)</td>
    </tr>
    <tr>
       <td>HypeSquad Balance</td>
       <td><img src="/img/hypesquadbalance.svg"></img></td>
-      <td>✅</td>
+      <td>❌</td>
       <td>Taking the HypeSquad <a href="https://support.discord.com/hc/en-us/articles/360007553672-HypeSquad-House-Breakdown">Test</a>.</td>
       <td>256 (2^8)</td>
    </tr>


### PR DESCRIPTION
Updated badge status from '✅' to '❌' for HypeSquad badges.



## Name of Resource:
Suppression complète des badges Hype Squad

## Description of Resource:
A few weeks ago the entire HypeSquad (Balance, Bravery and Brilliance) were removed

## A Link to the Resource:
n/a

## Discord ID(s) of the Creator(s):
858011419760132137
